### PR TITLE
Add logger type to allow logging with a prefix

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,150 @@
+package glog
+
+import (
+	"fmt"
+)
+
+// Logger provides logging functionality with additional prefixing.
+type Logger struct {
+	*loggingT
+	Verbose
+	prefix string
+}
+
+// NewLogger creates a Logger instance with empty prefix.
+func NewLogger() *Logger {
+	return &Logger{
+		loggingT: &logging,
+		Verbose:V(logging.verbosity),
+	}
+}
+
+// NewLoggerWithPrefix creates a Logger with a given prefix.
+func NewLoggerWithPrefix(format string, a ...interface{}) *Logger {
+	return &Logger{
+		loggingT: &logging,
+		Verbose: V(logging.verbosity),
+		prefix:   fmt.Sprintf(format, a...),
+	}
+}
+
+// AddPrefix appends existing logger with a specified prefix.
+func (l *Logger) AddPrefix(format string, a ...interface{}) *Logger {
+	l.prefix += fmt.Sprintf(format, a...)
+	return l
+}
+
+// Info is equivalent to the global Info function, with the addition of prefix from this Logger.
+func (l *Logger) Info(args ...interface{}) {
+	if l.Verbose {
+		l.print(infoLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Infoln is equivalent to the global Infoln function, with the addition of prefix from this Logger.
+func (l *Logger) Infoln(args ...interface{}) {
+	if l.Verbose {
+		l.println(infoLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Infof is equivalent to the global Infof function, with the addition of prefix from this Logger.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	if l.Verbose {
+		l.printf(infoLog, l.pfx(format), args...)
+	}
+}
+
+// Warning is equivalent to the global Warning function, with the addition of prefix from this Logger.
+func (l *Logger) Warning(args ...interface{}) {
+	if l.Verbose {
+		l.print(warningLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Warningln is equivalent to the global Warningln function, with the addition of prefix from this Logger.
+func (l *Logger) Warningln(args ...interface{}) {
+	if l.Verbose {
+		l.println(warningLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Warningf is equivalent to the global Warningf function, with the addition of prefix from this Logger.
+func (l *Logger) Warningf(format string, args ...interface{}) {
+	if l.Verbose {
+		l.printf(warningLog, l.pfx(format), args...)
+	}
+}
+
+// Error is equivalent to the global Error function, with the addition of prefix from this Logger.
+func (l *Logger) Error(args ...interface{}) {
+	if l.Verbose {
+		l.print(errorLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Errorln is equivalent to the global Errorln function, with the addition of prefix from this Logger.
+func (l *Logger) Errorln(args ...interface{}) {
+	if l.Verbose {
+		l.println(errorLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Errorf is equivalent to the global Errorf function, with the addition of prefix from this Logger.
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	if l.Verbose {
+		l.printf(errorLog, l.pfx(format), args...)
+	}
+}
+
+// Fatal is equivalent to the global Fatal function, with the addition of prefix from this Logger.
+func (l *Logger) Fatal(args ...interface{}) {
+	if l.Verbose {
+		l.print(fatalLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Fatalln is equivalent to the global Fatalln function, with the addition of prefix from this Logger.
+func (l *Logger) Fatalln(args ...interface{}) {
+	if l.Verbose {
+		l.println(fatalLog, l.extendWithPrefix(args)...)
+	}
+}
+
+// Fatalf is equivalent to the global Fatalf function, with the addition of prefix from this Logger.
+func (l *Logger) Fatalf(format string, args ...interface{}) {
+	l.printf(fatalLog, l.pfx(format), args...)
+}
+
+func (l *Logger) extendWithPrefix(args []interface{}) []interface{} {
+	if l.prefix != "" {
+		args = append([]interface{}{
+			l.prefix,
+		}, args...)
+	}
+	return args
+}
+
+func (l *Logger) pfx(log string) string {
+	return fmt.Sprintf("%v %v", l.prefix, log)
+}
+
+// V reports whether verbosity at the call site is at least the requested level.
+// The returned value is a boolean of type Verbose, which implements Info, Infoln
+// and Infof. These methods will write to the Info log if called.
+// Thus, one may write either
+//	if glog.V(2) { glog.Info("log this") }
+// or
+//	glog.V(2).Info("log this")
+// The second form is shorter but the first is cheaper if logging is off because it does
+// not evaluate its arguments.
+//
+// Whether an individual call to V generates a log record depends on the setting of
+// the -v and --vmodule flags; both are off by default. If the level in the call to
+// V is at least the value of -v, or of -vmodule for the source file containing the
+// call, the V call will log.
+func (l *Logger) V(level Level) *Logger {
+	l.Verbose = V(level)
+	return l
+}
+

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,254 @@
+package glog
+
+import (
+	"bytes"
+	"testing"
+)
+
+var fakeStdout bytes.Buffer
+
+// Test that using the prefix works.
+func TestPrefix(t *testing.T) {
+
+	for _, test := range loggerTests {
+		t.Run(test.name, func(t *testing.T) {
+
+			setFlags()
+			defer logging.swap(logging.newBuffers())
+
+			prefixedLogger := NewLoggerWithPrefix("examplePrefix")
+			test.loggingFunc(prefixedLogger)
+			if !contains(test.severity, test.logCharacter, t) {
+				t.Errorf("%s has wrong character: %q", severityName[test.severity], contents(test.severity))
+			}
+			if !contains(test.severity, "hello", t) {
+				t.Errorf("%s failed", test.severity)
+			}
+			if !contains(test.severity, "examplePrefix", t) {
+				t.Errorf("%s failed", test.severity)
+			}
+		})
+	}
+}
+
+func TestMultiPrefix(t *testing.T) {
+
+	for _, test := range loggerTests {
+		t.Run(test.name, func(t *testing.T) {
+
+			setFlags()
+			defer logging.swap(logging.newBuffers())
+
+			prefixedLogger := NewLoggerWithPrefix("examplePrefix")
+			prefixedLogger.AddPrefix("secondPrefix")
+			test.loggingFunc(prefixedLogger)
+			if !contains(test.severity, test.logCharacter, t) {
+				t.Errorf("%s has wrong character: %q", severityName[test.severity], contents(test.severity))
+			}
+			if !contains(test.severity, "hello", t) {
+				t.Errorf("%s failed", severityName[test.severity])
+			}
+			if !contains(test.severity, "examplePrefixsecondPrefix", t) {
+				t.Errorf("%s failed", severityName[test.severity], )
+			}
+		})
+	}
+}
+
+func TestMultiPrefixWithLogLevel(t *testing.T) {
+
+	for _, test := range verboseLoggerTests {
+		t.Run(test.name, func(t *testing.T) {
+			setFlags()
+			defer logging.swap(logging.newBuffers())
+
+			prefixedLogger := NewLoggerWithPrefix("examplePrefix")
+			prefixedLogger.AddPrefix("secondPrefix")
+			prefixedLogger.verbosity.set(3)
+			test.loggingFunc(prefixedLogger)
+
+			if contains(test.severity, test.logCharacter, t) {
+				t.Errorf("%s has wrong character: %q", severityName[test.severity], contents(test.severity))
+			}
+			if contains(test.severity, "hello", t) {
+				t.Errorf("%s failed", severityName[test.severity])
+			}
+			if contains(test.severity, "examplePrefixsecondPrefix", t) {
+				t.Errorf("%s failed", severityName[test.severity], )
+			}
+
+			prefixedLogger.verbosity.set(4)
+			test.loggingFunc(prefixedLogger)
+
+			if !contains(test.severity, test.logCharacter, t) {
+				t.Errorf("%s has wrong character: %q", severityName[test.severity], contents(test.severity))
+			}
+			if !contains(test.severity, "hello", t) {
+				t.Errorf("%s failed", severityName[test.severity])
+			}
+			if !contains(test.severity, "examplePrefixsecondPrefix", t) {
+				t.Errorf("%s failed", severityName[test.severity], )
+			}
+		})
+	}
+}
+
+var loggerTests = []struct {
+	name         string
+	severity     severity
+	logCharacter string
+	loggingFunc  func(l *Logger)
+}{
+	{
+		name:         "Info",
+		severity:     infoLog,
+		logCharacter: "I",
+		loggingFunc: func(l *Logger) {
+			l.Info("hello")
+		},
+	},
+	{
+		name:         "Infoln",
+		severity:     infoLog,
+		logCharacter: "I",
+		loggingFunc: func(l *Logger) {
+			l.Infoln("hello")
+		},
+	},
+	{
+		name:         "Infof",
+		severity:     infoLog,
+		logCharacter: "I",
+		loggingFunc: func(l *Logger) {
+			l.Infof("hello: %s", "<NAME>")
+		},
+	},
+	{
+		name:         "Warning",
+		severity:     warningLog,
+		logCharacter: "W",
+		loggingFunc: func(l *Logger) {
+			l.Warning("hello")
+		},
+	},
+	{
+		name:         "Warningln",
+		severity:     warningLog,
+		logCharacter: "W",
+		loggingFunc: func(l *Logger) {
+			l.Warningln("hello")
+		},
+	},
+	{
+		name:         "Warningf",
+		severity:     warningLog,
+		logCharacter: "W",
+		loggingFunc: func(l *Logger) {
+			l.Warningf("hello: %s", "<NAME>")
+		},
+	},
+	{
+		name:         "Error",
+		severity:     errorLog,
+		logCharacter: "E",
+		loggingFunc: func(l *Logger) {
+			l.Error("hello")
+		},
+	},
+	{
+		name:         "Errorln",
+		severity:     errorLog,
+		logCharacter: "E",
+		loggingFunc: func(l *Logger) {
+			l.Errorln("hello")
+		},
+	},
+	{
+		name:         "Errorf",
+		severity:     errorLog,
+		logCharacter: "E",
+		loggingFunc: func(l *Logger) {
+			l.Errorf("hello: %s", "<NAME>")
+		},
+	},
+}
+
+var verboseLoggerTests = []struct {
+	name         string
+	severity     severity
+	logCharacter string
+	loggingFunc  func(l *Logger)
+}{
+	{
+		name:         "Info",
+		severity:     infoLog,
+		logCharacter: "I",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Info("hello")
+		},
+	},
+	{
+		name:         "Infoln",
+		severity:     infoLog,
+		logCharacter: "I",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Infoln("hello")
+		},
+	},
+	{
+		name:         "Infof",
+		severity:     infoLog,
+		logCharacter: "I",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Infof("hello: %s", "<NAME>")
+		},
+	},
+	{
+		name:         "Warning",
+		severity:     warningLog,
+		logCharacter: "W",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Warning("hello")
+		},
+	},
+	{
+		name:         "Warningln",
+		severity:     warningLog,
+		logCharacter: "W",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Warningln("hello")
+		},
+	},
+	{
+		name:         "Warningf",
+		severity:     warningLog,
+		logCharacter: "W",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Warningf("hello: %s", "<NAME>")
+		},
+	},
+	{
+		name:         "Error",
+		severity:     errorLog,
+		logCharacter: "E",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Error("hello")
+		},
+	},
+	{
+		name:         "Errorln",
+		severity:     errorLog,
+		logCharacter: "E",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Errorln("hello")
+		},
+	},
+	{
+		name:         "Errorf",
+		severity:     errorLog,
+		logCharacter: "E",
+		loggingFunc: func(l *Logger) {
+			l.V(4).Errorf("hello: %s", "<NAME>")
+		},
+	},
+}


### PR DESCRIPTION
This change is to simplify the logging code and add some contextual information to the logs. 
For example:
	glog := glog.NewLoggerWithPrefix("[instance %s('%s')]", instanceId, instanceName)
       ...some code here...
	glog.V(2).Infof("Got os: %s", osType)
      // This ends up logging : 
I0912 10:57:35.006941   23847 .go:155] [instance i-0344dd5b2688699dd('aws-vm-1')] Got os: windows